### PR TITLE
fix: include time in date formatting utility

### DIFF
--- a/src/lib/utils/date-helpers.ts
+++ b/src/lib/utils/date-helpers.ts
@@ -18,8 +18,9 @@ export function formatDate(date: Date | string): string {
  */
 export function formatDateTime(date: Date | string): string {
   const dateObj = typeof date === 'string' ? new Date(date) : date;
-  
-  return dateObj.toLocaleDateString('en-GB', {
+
+  // Use toLocaleString to include both date and time components
+  return dateObj.toLocaleString('en-GB', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',


### PR DESCRIPTION
## Summary
- ensure `formatDateTime` includes time by using `toLocaleString`

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c127bc64483268519c999c6e283ff