### PR TITLE
Refactor OpenAI client initialization to singleton

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,15 +1,17 @@
 import { AVAILABLE_MODELS } from './models';
+import { OpenAI } from 'openai';
 
-const getOpenAIClient = () => {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error('OpenAI API key is not configured. Please set OPENAI_API_KEY environment variable.');
+let openaiClient: OpenAI | null = null;
+
+const getOpenAIClient = (): OpenAI => {
+  if (!openaiClient) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error('OpenAI API key is not configured. Please set OPENAI_API_KEY environment variable.');
+    }
+    openaiClient = new OpenAI({ apiKey });
   }
-  
-  const { OpenAI } = require('openai');
-  return new OpenAI({
-    apiKey: apiKey,
-  });
+  return openaiClient;
 };
 
 const isApiKeyAvailable = () => {
@@ -700,4 +702,4 @@ Call to Action:
 }
 
 // Export the function instead of an instance to avoid client-side execution
-export { getOpenAIClient }; 
+export { getOpenAIClient };


### PR DESCRIPTION
## Summary
- refactor OpenAI integration to use ES module import and lazy singleton client
- expose `getOpenAIClient` returning shared instance for all calls

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c172ec9f88326bba447013960aa31